### PR TITLE
Add nginx config with set up for https/SSL

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -30,5 +30,5 @@ python_version = "3.8"
 
 [scripts]
 serve = "python run.py"
-deploy = "gunicorn --bind 0.0.0.0:5000 wsgi"
+deploy = "gunicorn --bind 127.0.0.1:5000 wsgi"
 

--- a/coronavirus-annotation.conf
+++ b/coronavirus-annotation.conf
@@ -1,15 +1,7 @@
 server {
     listen 80 default_server;
     server_name coronavirus-annotation-2.sci.utah.edu;
-    return 301 https://$server_name$request_uri;
-}
-
-server {
-    listen 443 ssl;
-    server_name coronavirus-annotation-2.sci.utah.edu;
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers         HIGH:!aNULL:!MD5;
-
+    
     location / {
         proxy_pass http://127.0.0.1:8000;
     }

--- a/coronavirus-annotation.conf
+++ b/coronavirus-annotation.conf
@@ -1,0 +1,37 @@
+user  nginx;
+worker_processes 1;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+events {
+    worker_connections 1024;
+}
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    keepalive_timeout  7200;
+
+    root /home/ubuntu/workforce-frontend/frontend/dist;
+    index index.html;
+
+    server {
+        listen 80 default_server;
+        server_name coronavirus-annotation-2.sci.utah.edu;
+	    return 301 https://$server_name$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name coronavirus-annotation-2.sci.utah.edu;
+        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
+        location / {
+            proxy_pass http://127.0.0.1:5000;
+        }
+    }
+}

--- a/coronavirus-annotation.conf
+++ b/coronavirus-annotation.conf
@@ -1,36 +1,16 @@
-worker_processes 1;
-error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
-events {
-    worker_connections 1024;
+server {
+    listen 80 default_server;
+    server_name coronavirus-annotation-2.sci.utah.edu;
+    return 301 https://$server_name$request_uri;
 }
-http {
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
-    access_log  /var/log/nginx/access.log  main;
-    sendfile        on;
-    keepalive_timeout  7200;
 
-    root /home/ubuntu/workforce-frontend/frontend/dist;
-    index index.html;
+server {
+    listen 443 ssl;
+    server_name coronavirus-annotation-2.sci.utah.edu;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
 
-    server {
-        listen 80 default_server;
-        server_name coronavirus-annotation-2.sci.utah.edu;
-	    return 301 https://$server_name$request_uri;
-    }
-
-    server {
-        listen 443 ssl;
-        server_name coronavirus-annotation-2.sci.utah.edu;
-        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers         HIGH:!aNULL:!MD5;
-
-        location / {
-            proxy_pass http://127.0.0.1:5000;
-        }
+    location / {
+        proxy_pass http://127.0.0.1:8000;
     }
 }

--- a/coronavirus-annotation.conf
+++ b/coronavirus-annotation.conf
@@ -1,4 +1,3 @@
-user  nginx;
 worker_processes 1;
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;

--- a/coronavirus-annotation.conf
+++ b/coronavirus-annotation.conf
@@ -1,8 +1,26 @@
 server {
-    listen 80 default_server;
     server_name coronavirus-annotation-2.sci.utah.edu;
     
     location / {
-        proxy_pass http://127.0.0.1:8000;
+        proxy_pass http://127.0.0.1:5000;
     }
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/coronavirus-annotation-2.sci.utah.edu/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/coronavirus-annotation-2.sci.utah.edu/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+server {
+    if ($host = coronavirus-annotation-2.sci.utah.edu) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    listen 80 default_server;
+    server_name coronavirus-annotation-2.sci.utah.edu;
+    return 404; # managed by Certbot
+
+
 }


### PR DESCRIPTION
This adds https and serves the site at https://coronavirus-annotation-2.sci.utah.edu/ (note, no port required any more). This should fix the open issues for the deployment and should mean it's all set up as desired. Let me know if you have any problems, Jen